### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/assets/bootstrap/js/bootstrap.js
+++ b/assets/bootstrap/js/bootstrap.js
@@ -109,7 +109,7 @@ if (typeof jQuery === 'undefined') {
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = $(selector)
+    var $parent = $.find(selector)
 
     if (e) e.preventDefault()
 


### PR DESCRIPTION
Fixes [https://github.com/jordanistan/iamjordanrobison/security/code-scanning/1](https://github.com/jordanistan/iamjordanrobison/security/code-scanning/1)

To fix the problem, we need to ensure that the `data-target` attribute is properly sanitized before being used as a selector. One way to do this is to use the `$.find` method instead of `$`, which will interpret the `data-target` value strictly as a CSS selector and not as HTML. This prevents any potential XSS attacks by ensuring that the value is not reinterpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
