### PR TITLE
Fix code scanning alert no. 20: Unsafe jQuery plugin

### DIFF
--- a/assets/bootstrap/js/bootstrap.js
+++ b/assets/bootstrap/js/bootstrap.js
@@ -2159,7 +2159,7 @@ if (typeof jQuery === 'undefined') {
   var Affix = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
-    this.$target = $(this.options.target)
+    this.$target = $(document).find(this.options.target)
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 


### PR DESCRIPTION
Fixes [https://github.com/jordanistan/iamjordanrobison/security/code-scanning/20](https://github.com/jordanistan/iamjordanrobison/security/code-scanning/20)

To fix the problem, we need to ensure that the `options.target` value is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `$` method, which ensures that the input is always interpreted as a selector.

- Replace the use of `$(this.options.target)` with `$(document).find(this.options.target)` to ensure that the `target` option is always treated as a CSS selector.
- This change should be made in the `Affix` class constructor where `this.$target` is assigned.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
