### PR TITLE
Fix code scanning alert no. 13: Unsafe jQuery plugin

### DIFF
--- a/assets/bootstrap/js/bootstrap.js
+++ b/assets/bootstrap/js/bootstrap.js
@@ -544,7 +544,7 @@ if (typeof jQuery === 'undefined') {
   var Collapse = function (element, options) {
     this.$element      = $(element)
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
-    this.$trigger      = $(this.options.trigger).filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
+    this.$trigger      = $.find(this.options.trigger).filter('[href="#' + element.id + '"], [data-target="#' + element.id + '"]')
     this.transitioning = null
 
     if (this.options.parent) {


### PR DESCRIPTION
Fixes [https://github.com/jordanistan/iamjordanrobison/security/code-scanning/13](https://github.com/jordanistan/iamjordanrobison/security/code-scanning/13)

To fix the problem, we need to ensure that the `trigger` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of directly using `$(this.options.trigger)`. This change will prevent the evaluation of the `trigger` option as HTML, thus mitigating the risk of XSS.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
